### PR TITLE
Fix help and helpshort to correctly interpolate %s in __doc__

### DIFF
--- a/gflags.py
+++ b/gflags.py
@@ -2392,25 +2392,31 @@ class HelpFlag(BooleanFlag):
   def __init__(self):
     BooleanFlag.__init__(self, "help", 0, "show this help",
                          short_name="?", allow_override=1)
+
   def Parse(self, arg):
     if arg:
-      doc = sys.modules["__main__"].__doc__
+      doc = sys.modules["__main__"].__doc__.replace('%s', sys.argv[0])
       flags = str(FLAGS)
       print doc or ("\nUSAGE: %s [flags]\n" % sys.argv[0])
       if flags:
         print "flags:"
         print flags
       sys.exit(1)
+
+
 class HelpXMLFlag(BooleanFlag):
   """Similar to HelpFlag, but generates output in XML format."""
   def __init__(self):
     BooleanFlag.__init__(self, 'helpxml', False,
                          'like --help, but generates XML output',
                          allow_override=1)
+
   def Parse(self, arg):
     if arg:
       FLAGS.WriteHelpInXMLFormat(sys.stdout)
       sys.exit(1)
+
+
 class HelpshortFlag(BooleanFlag):
   """
   HelpshortFlag is a special boolean flag that prints usage
@@ -2422,9 +2428,10 @@ class HelpshortFlag(BooleanFlag):
   def __init__(self):
     BooleanFlag.__init__(self, "helpshort", 0,
                          "show usage only for this module", allow_override=1)
+
   def Parse(self, arg):
     if arg:
-      doc = sys.modules["__main__"].__doc__
+      doc = sys.modules["__main__"].__doc__.replace('%s', sys.argv[0])
       flags = FLAGS.MainModuleHelp()
       print doc or ("\nUSAGE: %s [flags]\n" % sys.argv[0])
       if flags:

--- a/gflags2man.py
+++ b/gflags2man.py
@@ -36,7 +36,7 @@ Run the program, parse the output, and then format that into a man
 page.
 
 Usage:
-  gflags2man <program> [program] ...
+  %s <program> [program] ...
 """
 
 # TODO(csilvers): work with windows paths (\) as well as unix (/)


### PR DESCRIPTION
HelpXMLFlag has been doing this all along, and it looks like HelpFlag
and HelpShortFlag should too.
