### PR TITLE
Make gflags importable from a git submodule

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from gflags import *


### PR DESCRIPTION
I clone this into a third_party submodule of my repos, rather than installing or putting in a pythonpath, and suggest that others do the same. This change allows me to simply 
    from third_party import gflags

Ultimately, the better solution is replacing the build system with bazel (which would create the **init**.py automatically), though this is still helpful for convenient notation (vs from third_party.gflags import gflags)
