### PR TITLE
setup.py: Install the script as 'scripts', rather than 'data_files'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(name='python-gflags',
       author_email='google-gflags@googlegroups.com',
       url='https://github.com/google/python-gflags',
       packages=['gflags', 'gflags.third_party', 'gflags.third_party.pep257'],
-      data_files=[('bin', ['gflags2man.py'])],
+      scripts=['gflags2man.py'],
       requires=['six'],
       classifiers=[
           'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Install the Python script using the 'scripts' key rather than
the 'data_files' hack. This ensures that it is installed
in the correct location (respecting install options) and its shebang
is updated to match the correct Python interpreter.

This is the same patch as I've sent back in 2012, rebased on top
of the newest release.